### PR TITLE
Fix: Update Polaris tokens CSS import path

### DIFF
--- a/src/components/Polaris.css
+++ b/src/components/Polaris.css
@@ -1,4 +1,4 @@
-@import '@shopify/polaris-tokens/css/styles.css';
+@import '~@shopify/polaris-tokens/css/styles.css';
 
 /* Animations */
 


### PR DESCRIPTION
This commit fixes a compilation error caused by an incorrect import path for the Polaris tokens CSS file. The path has been updated to include a `~` prefix, which is a common convention for resolving imports from `node_modules` in webpack configurations.

This change resolves the build failure and ensures that the Polaris styles are correctly applied to the application.